### PR TITLE
Fix test errors for GitHub Actions workflow

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -24,7 +24,7 @@ jest.mock('@ai-sdk/google', () => ({
 }));
 
 jest.mock('ai', () => ({
-  generateText: jest.fn(),
+  streamText: jest.fn(),
 }));
 
 jest.mock('ignore', () => {
@@ -51,10 +51,10 @@ import {
   LLM,
   FileSummary
 } from '../index';
-import { generateText } from 'ai';
+import { streamText } from 'ai';
 
-// Helper type to properly mock functions
-type MockedFunction<T extends (...args: any[]) => any> = jest.Mock<ReturnType<T>, Parameters<T>>;
+// Helper type for Jest mocks
+type MockFunction = jest.Mock<any, any>;
 
 describe('Code Summarizer', () => {
   beforeEach(() => {
@@ -138,8 +138,8 @@ describe('Code Summarizer', () => {
   describe('GeminiLLM', () => {
     it('should respect summary options', async () => {
       // Mock implementation
-      const mockedGenerateText = generateText as jest.Mock;
-      mockedGenerateText.mockResolvedValue('Mocked summary');
+      const mockedStreamText = streamText as MockFunction;
+      mockedStreamText.mockResolvedValue('Mocked summary');
       
       const llm = new GeminiLLM('test-api-key');
       const options: SummaryOptions = {
@@ -149,16 +149,16 @@ describe('Code Summarizer', () => {
       
       await llm.summarize('function test() {}', 'JavaScript', options);
       
-      // Check if generateText was called with the right parameters
-      expect(mockedGenerateText).toHaveBeenCalled();
-      const callArg = mockedGenerateText.mock.calls[0][0];
+      // Check if streamText was called with the right parameters
+      expect(mockedStreamText).toHaveBeenCalled();
+      const callArg = mockedStreamText.mock.calls[0][0];
       expect(callArg.prompt).toContain('detailed analysis');
       expect(callArg.prompt).toContain('1000 characters');
     });
     
     it('should handle API errors gracefully', async () => {
-      const mockedGenerateText = generateText as jest.Mock;
-      mockedGenerateText.mockRejectedValue(new Error('API error'));
+      const mockedStreamText = streamText as MockFunction;
+      mockedStreamText.mockRejectedValue(new Error('API error'));
       
       const llm = new GeminiLLM('test-api-key');
       const result = await llm.summarize('function test() {}', 'JavaScript');
@@ -167,13 +167,13 @@ describe('Code Summarizer', () => {
     });
 
     it('should use default options when none provided', async () => {
-      const mockedGenerateText = generateText as jest.Mock;
-      mockedGenerateText.mockResolvedValue('Default summary');
+      const mockedStreamText = streamText as MockFunction;
+      mockedStreamText.mockResolvedValue('Default summary');
       
       const llm = new GeminiLLM('test-api-key');
       await llm.summarize('function test() {}', 'JavaScript');
       
-      const callArg = mockedGenerateText.mock.calls[0][0];
+      const callArg = mockedStreamText.mock.calls[0][0];
       
       // Should not contain detail level specific text
       expect(callArg.prompt).not.toContain('very brief');

--- a/__tests__/mock-codebase.test.ts
+++ b/__tests__/mock-codebase.test.ts
@@ -3,9 +3,9 @@ import * as fs from 'fs';
 import { jest } from '@jest/globals';
 import { findCodeFiles, GeminiLLM, summarizeFiles, SummaryOptions } from '../index';
 
-// Only mock the generateText function, not the actual file system operations
+// Only mock the streamText function, not the actual file system operations
 jest.mock('ai', () => ({
-  generateText: jest.fn().mockImplementation(() => Promise.resolve('Mocked summary for testing'))
+  streamText: jest.fn().mockImplementation(() => Promise.resolve('Mocked summary for testing'))
 }));
 
 jest.mock('@ai-sdk/google', () => ({
@@ -73,15 +73,15 @@ describe('Mock Codebase Integration Tests', () => {
     expect(highDetailSummaries[0].summary).toBe('Mocked summary for testing');
     
     // Verify the options were passed correctly
-    const { generateText } = require('ai');
-    const mockCalls = generateText.mock.calls;
+    const { streamText } = require('ai');
+    const mockCalls = streamText.mock.calls;
     
     // Find calls that include specific detail levels in their prompts
-    const lowDetailCall = mockCalls.find((call: any) => 
+    const lowDetailCall = mockCalls.find((call: any[]) => 
       call[0]?.prompt?.includes('Keep it very brief')
     );
     
-    const highDetailCall = mockCalls.find((call: any) => 
+    const highDetailCall = mockCalls.find((call: any[]) => 
       call[0]?.prompt?.includes('detailed analysis')
     );
     

--- a/index.ts
+++ b/index.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import dotenv from 'dotenv';
 import { google } from '@ai-sdk/google';
-import { generateText } from 'ai';
+import { streamText } from 'ai';
 import ignore from 'ignore';
 import { Command } from 'commander';
 
@@ -51,7 +51,7 @@ Keep the summary under ${summaryOptions.maxLength} characters.
 
 ${code}`;
       
-      const result = await generateText({
+      const result = await streamText({
         model: google('gemini-2.0-flash-exp'),
         prompt
       });


### PR DESCRIPTION
This PR fixes the test failures that occurred when running the GitHub Actions workflow. The main changes are:

1. Update imports in the codebase to use the current API:
   - Replace `generateText` with `streamText` from the `ai` package
   - Correctly configure type definitions for Jest mocks to avoid TypeScript errors

2. Update test files to work with the new API:
   - Use correct mock implementations for `streamText`
   - Fix TypeScript type issues with Jest mocks

These changes align the code with the expected API of the Vercel AI SDK. The tests should now pass when run in GitHub Actions.
